### PR TITLE
adding ability to pass in parameters for the simulated annealing process

### DIFF
--- a/src/graspit_commander/graspit_commander.py
+++ b/src/graspit_commander/graspit_commander.py
@@ -12,6 +12,7 @@ from graspit_interface.msg import (
     Robot,
     SearchContact,
     SearchSpace,
+    SimAnnParams,
     PlanGraspsAction,
     PlanGraspsGoal
 )
@@ -333,7 +334,8 @@ class GraspitCommander(object):
                    search_contact=SearchContact(SearchContact.CONTACT_PRESET),
                    max_steps=70000,
                    feedback_cb=None,
-                   feedback_num_steps=-1):
+                   feedback_num_steps=-1,
+                   sim_ann_params=SimAnnParams()):
         try:
             rospy.init_node(cls.ROS_NODE_NAME, anonymous=True)
         except ROSException:
@@ -348,7 +350,8 @@ class GraspitCommander(object):
                               search_space=search_space,
                               search_contact=search_contact,
                               max_steps=max_steps,
-                              feedback_num_steps=feedback_num_steps)
+                              feedback_num_steps=feedback_num_steps,
+                              sim_ann_params=sim_ann_params)
 
         client.send_goal(goal, feedback_cb=feedback_cb)
         client.wait_for_result()


### PR DESCRIPTION
Example usage:
```
from graspit_commander import GraspitCommander
GraspitCommander.clearWorld()
GraspitCommander.loadWorld("plannerMug")

from graspit_interface.msg import SimAnnParams
sim_ann_params = SimAnnParams(set_custom_params=True,
                              YC=7.0, HC=7.0,
                              YDIMS=8.0, HDIMS=8.0,
                              NBR_ADJ=1.0, ERR_ADJ=1.0e-6,
                              DEF_T0=1e6, DEF_K0=30000) # these are GraspIt!'s default, you can change to values that suit your purpose

GraspitCommander.planGrasps(max_steps=40000, sim_ann_params=sim_ann_params)
```